### PR TITLE
Update tests to include V8 / Update to vsjdbc 12.0.0

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
       DEFAULT_EXASOL_DB_VERSION: "7.1.25"
     steps:
       - name: Free Disk Space
-        if: ${{ false }}
+        if: ${{ true }}
         run: |
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        exasol_db_version: ["7.1.25"]
+        exasol_db_version: ["7.1.25", "8.24.0"]
     env:
       DEFAULT_EXASOL_DB_VERSION: "7.1.25"
     steps:

--- a/.project-keeper.yml
+++ b/.project-keeper.yml
@@ -10,4 +10,5 @@ build:
   exasolDbVersions:
     - "7.1.25"
     - "8.24.0"
+  freeDiskSpace: true
 excludes:

--- a/.project-keeper.yml
+++ b/.project-keeper.yml
@@ -9,4 +9,5 @@ build:
   runnerOs: ubuntu-20.04
   exasolDbVersions:
     - "7.1.25"
+    - "8.24.0"
 excludes:

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [3.0.0](changes_3.0.0.md)
 * [2.1.4](changes_2.1.4.md)
 * [2.1.3](changes_2.1.3.md)
 * [2.1.2](changes_2.1.2.md)

--- a/doc/changes/changes_3.0.0.md
+++ b/doc/changes/changes_3.0.0.md
@@ -1,6 +1,6 @@
 # Virtual Schema for DB2 3.0.0, released 2024-03-26
 
-Code name: Char set is always `utf-8`, deprecated IMPORT_DATA_TYPES `FROM_RESULT_SET` value .
+Code name: Charset is always `utf-8`, deprecated IMPORT_DATA_TYPES `FROM_RESULT_SET` value
 
 ## Summary
 
@@ -11,5 +11,5 @@ An exception will be thrown when users use`FROM_RESULT_SET`. The exception messa
 
 ## Refactoring
 
-* #25: Update tests to V8 VSMYSQL / Update to vsjdbc 12.0.0
+* #25: Updated tests to Exasol v8, updated to vsjdbc 12.0.0
 

--- a/doc/changes/changes_3.0.0.md
+++ b/doc/changes/changes_3.0.0.md
@@ -1,4 +1,4 @@
-# Virtual Schema for DB2 3.0.0, released 2024-??-??
+# Virtual Schema for DB2 3.0.0, released 2024-03-26
 
 Code name: Char set is always `utf-8`, deprecated IMPORT_DATA_TYPES `FROM_RESULT_SET` value .
 

--- a/doc/changes/changes_3.0.0.md
+++ b/doc/changes/changes_3.0.0.md
@@ -1,0 +1,15 @@
+# Virtual Schema for DB2 3.0.0, released 2024-??-??
+
+Code name: Char set is always `utf-8`, deprecated IMPORT_DATA_TYPES `FROM_RESULT_SET` value .
+
+## Summary
+
+The behaviour when it comes to character sets is now simplified,
+The target char set is now always UTF-8.
+The `IMPORT_DATA_TYPES` property (and value `FROM_RESULT_SET`) are now deprecated (change in vs-common-jdbc):
+An exception will be thrown when users use`FROM_RESULT_SET`. The exception message warns the user that the value is no longer supported and the property itself is also deprecated.
+
+## Refactoring
+
+* #25: Update tests to V8 VSMYSQL / Update to vsjdbc 12.0.0
+

--- a/doc/user_guide/db2_user_guide.md
+++ b/doc/user_guide/db2_user_guide.md
@@ -56,7 +56,7 @@ The SQL statement below creates the adapter script, defines the Java class that 
 ```sql
 CREATE OR REPLACE JAVA ADAPTER SCRIPT ADAPTER.JDBC_ADAPTER AS
   %scriptclass com.exasol.adapter.RequestDispatcher;
-  %jar /buckets/<BFS service>/<bucket>/virtual-schema-dist-12.0.0-db2-2.1.4.jar;
+  %jar /buckets/<BFS service>/<bucket>/virtual-schema-dist-12.0.0-db2-3.0.0.jar;
   %jar /buckets/<BFS service>/<bucket>/db2jcc4.jar;
   %jar /buckets/<BFS service>/<bucket>/db2jcc_license_cu.jar;
 /
@@ -68,7 +68,7 @@ CREATE OR REPLACE JAVA ADAPTER SCRIPT ADAPTER.JDBC_ADAPTER AS
 ```sql
 CREATE OR REPLACE JAVA ADAPTER SCRIPT ADAPTER.JDBC_ADAPTER AS
   %scriptclass com.exasol.adapter.RequestDispatcher;
-  %jar /buckets/<BFS service>/<bucket>/virtual-schema-dist-12.0.0-db2-2.1.4.jar;
+  %jar /buckets/<BFS service>/<bucket>/virtual-schema-dist-12.0.0-db2-3.0.0.jar;
   %jar /buckets/<BFS service>/<bucket>/db2jcc4.jar;
   %jar /buckets/<BFS service>/<bucket>/db2jcc_license_cu.jar;
   %jar /buckets/<BFS service>/<bucket>/db2jcc_license_cisuz.jar;

--- a/pk_generated_parent.pom
+++ b/pk_generated_parent.pom
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>db2-virtual-schema-generated-parent</artifactId>
-    <version>2.1.4</version>
+    <version>3.0.0</version>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>db2-virtual-schema</artifactId>
-    <version>2.1.4</version>
+    <version>3.0.0</version>
     <name>Virtual Schema for DB2</name>
     <description>Virtual Schema for connecting DB2 as a data source to Exasol</description>
     <url>https://github.com/exasol/db2-virtual-schema/</url>
@@ -183,7 +183,7 @@
     <parent>
         <artifactId>db2-virtual-schema-generated-parent</artifactId>
         <groupId>com.exasol</groupId>
-        <version>2.1.4</version>
+        <version>3.0.0</version>
         <relativePath>pk_generated_parent.pom</relativePath>
     </parent>
 </project>

--- a/src/test/java/com/exasol/adapter/dialects/db2/IntegrationTestConfiguration.java
+++ b/src/test/java/com/exasol/adapter/dialects/db2/IntegrationTestConfiguration.java
@@ -8,7 +8,7 @@ public class IntegrationTestConfiguration {
     public static final String EXASOL_DOCKER_REFERENCE = "7.1.19";
     public static final DockerImageName DB2_DOCKER_REFERENCE = DockerImageName
             .parse("icr.io/db2_community/db2:11.5.8.0").asCompatibleSubstituteFor("ibmcom/db2");
-    public static final String VIRTUAL_SCHEMAS_JAR_NAME_AND_VERSION = "virtual-schema-dist-12.0.0-db2-2.1.4.jar";
+    public static final String VIRTUAL_SCHEMAS_JAR_NAME_AND_VERSION = "virtual-schema-dist-12.0.0-db2-3.0.0.jar";
     public static final Path PATH_TO_VIRTUAL_SCHEMAS_JAR = Path.of("target", VIRTUAL_SCHEMAS_JAR_NAME_AND_VERSION);
     public static final int DB2_PORT = 50000;
     public static final String JDBC_DRIVER_CONFIGURATION_FILE_NAME = "settings.cfg";


### PR DESCRIPTION
 major version increase because of earlier update to vsjdbc12.0.0
added exasol v8 to ci

Closes #25 